### PR TITLE
refactor: formatting, grammar

### DIFF
--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,43 +1,54 @@
 # WRITING GOOD COMMITS
 
-### What is good?
+## What is good?
 
 1. A good commit message is detailed.
-2. It focusses on the why more than the what or the how. What do you do is tracked by Git already. How do you do it is visible to the reader of your code already. 
+2. It focusses on the *why* more than the *what* or the *how*. What you do is tracked by Git already. How you do it is visible to the reader of your code already. 
+<br>
+<hr>
+<br>
 
-
-### Use the editor method to write commits 
+## Use the editor method to write commits
 
 We are used to writing: 
 ```bash 
 git commit -m "a message"
 ```
-Avoid that.
+**Avoid that.**
 
 Just run `git commit` and it will open up an editor.
  
-To configure your "default" editor:
+To configure your *"default"* editor:
 ```bash
 git config --global core.editor <name>
 
 # name could be nano/emacs/vim/whatever you like
 ```
+<br>
+<hr>
+<br>
 
-### Writing in the editor
+## Structure of the commit
 
-A good commit message is broken down into three parts.
+A good commit message is broken down into three parts:
 
-the top 
-< line break >
-the middle 
-< line break >
-the bottom 
+```
+> Top
+
+> Middle
+
+> Bottom
+```
+with *exactly* one-line spacing vertically between sections.
+
+<br>
  
-the top 
-should follow the format:
-\<type\>:\<summary or the subject line\> 
+The *top* should follow the format:
+```
+<type>: <summary or the subject line> 
+```
 
-where type is:
+where *type* is one of:
 
     feat: The new feature you're adding to a particular application
     fix: A bug fix
@@ -45,14 +56,18 @@ where type is:
     refactor: Refactoring a specific section of the codebase
     test: Everything related to testing
     docs: Everything related to documentation
-    chore: Regular code maintenance. 
+    chore: Regular code maintenance
 
-The net length of the top should not be more than 50 characters.
+**The net length of the top should not be more than 50 characters.**
 
 Do not end the subject line with a period.
+<br>
 
-the middle (or the body)
-Elaborate your work.Do not assume the reviewer understands what the original problem was, ensure you add it. Do not think your code is self-explanatory.
+The *middle* (or the body):
+```
+Elaborate your work. Do not assume the reviewer understands what the original problem was, ensure you add it. Do not think your code is self-explanatory.
+```
 
-the bottom 
-this is optional. Use it if you want to link this commit to an issue. 
+The *bottom* section is optional. Use it if you want to link the commit to an issue.
+<br>
+<hr> 


### PR DESCRIPTION
The documentation was earlier made to acquaint the contributors with
the standard practice for writing commits. This was done in a hurry to
avoid bad "initial" commits. Hence, the formatting and grammar were out
of order.
This commit adds the following:
  1. Formatting (code blocks, italicizing text, horizontal-rules)
  2. Grammar fixes
  3. Some changes in language for better understandability.